### PR TITLE
문진수 fix 리프레쉬 토큰생성 및 몬스터 생성주기 적용

### DIFF
--- a/client/public/js/game.js
+++ b/client/public/js/game.js
@@ -38,6 +38,7 @@ let towerType = 0; // 타워 종류
 let numOfInitialTowers = 0; // 초기 타워 개수
 let monsterLevel = 0; // 몬스터 레벨
 let monsterSpawnInterval = 0; // 몬스터 생성 주기
+let monsterInterval;
 
 const monsters = [];
 const towers = [];
@@ -446,10 +447,8 @@ function initGame() {
   placeBase(); // 기지 배치
   drawScoreboard(ctx, scoreBoardImage);
 
-  setInterval(spawnMonster, monsterSpawnInterval); // 설정된 몬스터 생성 주기마다 몬스터 생성
+  monsterInterval = setInterval(spawnMonster, monsterSpawnInterval); // 설정된 몬스터 생성 주기마다 몬스터 생성
 
-  // 58분마다 한번씩 토큰연장 현재 토큰 만료시간이 1시간으로 지정해놔서 게임실행 중 58분마다 연장해 주는 걸로 했습니다.
-  setInterval(extendAccessToken, 58 * 60 * 1000);
   gameLoop(); // 게임 루프 최초 실행
   isInitGame = true;
 }
@@ -547,6 +546,8 @@ Promise.all([
       if (data.waveLevel) monsterLevel = data.waveLevel; // 몬스터레벨 동기화
       if (data.monsterSpawnInterval) monsterSpawnInterval = data.monsterSpawnInterval;
       console.log(monsterSpawnInterval, data.monsterSpawnInterval);
+      clearInterval(monsterInterval);
+      monsterInterval = setInterval(spawnMonster, monsterSpawnInterval); // 설정된 몬스터 생성 주기마다 몬스터 생성
     }
 
     if (data.type === 'killMonster' && data.status === 'success') {

--- a/client/public/utils/extendAccessToken.js
+++ b/client/public/utils/extendAccessToken.js
@@ -1,17 +1,12 @@
-// 토큰 연장하기 (setInterval 함수를 이용하여 특정 주기마다 연장요청)
-
 /**
- * access token 체크 및 연장(갱신)하는 함수입니다.
+ * 리프레쉬 토큰 체크 및 엑세스 토큰 연장(갱신)하는 함수입니다.
  */
 export function extendAccessToken() {
-  const oldToken = localStorage.getItem('jwt');
-
-  // fetch로 api 요청을 보내 토큰 연장하기
   fetch('/api/tokenextend', {
     method: 'POST',
+    credentials: 'include', // 쿠키를 포함한 요청
     headers: {
       'Content-Type': 'application/json',
-      authorization: oldToken,
     },
   })
     .then(async (response) => {
@@ -25,8 +20,8 @@ export function extendAccessToken() {
       console.log(resData.message);
     })
     .catch((error) => {
-      console.error('토큰 연장 중 에러:', error);
-      alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
+      console.error('엑세스 토큰 갱신 중 에러:', error);
+      alert('리프레쉬 토큰이 만료되었습니다. 다시 로그인해 주세요');
       window.location.href = 'index.html';
     });
 }

--- a/server/app.js
+++ b/server/app.js
@@ -1,10 +1,11 @@
-import accountRouter from "./routes/accountRouter.js";
-import express from "express";
-import initSocket from "./init/socket.js";
-import dotenv from "dotenv";
-import { createServer } from "http";
-import { loadGameAssets } from "./init/assets.js";
-import errorHandleMiddleware from "./middlewares/errorHandleMiddleware.js";
+import accountRouter from './routes/accountRouter.js';
+import express from 'express';
+import initSocket from './init/socket.js';
+import dotenv from 'dotenv';
+import { createServer } from 'http';
+import { loadGameAssets } from './init/assets.js';
+import errorHandleMiddleware from './middlewares/errorHandleMiddleware.js';
+import cookieParser from 'cookie-parser';
 
 dotenv.config();
 
@@ -13,23 +14,24 @@ const PORT = process.env.SECRET_PORT;
 const app = express();
 const server = createServer(app);
 
+app.use(cookieParser());
 // body-parser
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(express.static("client/public"));
+app.use(express.static('client/public'));
 
-app.use("/api", accountRouter);
+app.use('/api', accountRouter);
 // 소켓 초기화
 initSocket(server);
 app.use(errorHandleMiddleware);
 
 server.listen(PORT, async () => {
-     console.log(`${PORT} 포트로 서버가 열렸습니다.`);
+  console.log(`${PORT} 포트로 서버가 열렸습니다.`);
 
-     try {
-          const assets = await loadGameAssets();
-          console.log("assets 파일이 정상적으로 로드되었습니다.");
-     } catch (error) {
-          console.error("assets 파일을 불러오는 데 실패했습니다.", error);
-     }
+  try {
+    const assets = await loadGameAssets();
+    console.log('assets 파일이 정상적으로 로드되었습니다.');
+  } catch (error) {
+    console.error('assets 파일을 불러오는 데 실패했습니다.', error);
+  }
 });


### PR DESCRIPTION
로그인 시 리프레쉬 토큰을 쿠키에 생성하게 하였고 클라에서 리프레쉬 토큰이 있으면 엑세스 토큰을 생성하게 하였습니다.

현재 엑세스 토큰은 헤더에 저장하고 있어 만료 시간은 10분으로 짧게 설정했습니다.

몬스터생성 주기는 웨이브 레벨상승시 데이터를 받아와서 기존에 실행되있던 setInterval함수를 중지하고 다시 실행하여 몬스터생성 주기를 변경하였습니다.